### PR TITLE
Tips: 补一条每日刷新的模型价目表（JSON / CSV）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1438,6 +1438,8 @@ MCP工具聚合：
 36. [Beam Search快速理解及代码解析](https://www.cnblogs.com/nickchen121/p/15499576.html)
 37. [基于 transformers 的 generate() 方法实现多样化文本生成：参数含义和算法原理解读](https://blog.csdn.net/muyao987/article/details/125917234)
 38. [The Ultra-Scale Playbook: Training LLMs on GPU Clusters](https://huggingface.co/spaces/nanotron/ultrascale-playbook)
+39. [llm-api-pricing](https://github.com/xyzs996/llm-api-pricing): 每日自动刷新的编程 Agent 模型价目表，JSON / CSV 可直接引用，网页版把每百万 token 价格和跑分排名放在同一行。
+40. [llm-cost-calculator](https://github.com/xyzs996/llm-cost-calculator): 单文件网页算价器，读上面那份 JSON，按调用时刻判 DeepSeek 峰谷价、按实际长度判长上下文档位、按自己的缓存命中率折算。
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>

--- a/README.md
+++ b/README.md
@@ -1438,8 +1438,7 @@ MCP工具聚合：
 36. [Beam Search快速理解及代码解析](https://www.cnblogs.com/nickchen121/p/15499576.html)
 37. [基于 transformers 的 generate() 方法实现多样化文本生成：参数含义和算法原理解读](https://blog.csdn.net/muyao987/article/details/125917234)
 38. [The Ultra-Scale Playbook: Training LLMs on GPU Clusters](https://huggingface.co/spaces/nanotron/ultrascale-playbook)
-39. [llm-api-pricing](https://github.com/xyzs996/llm-api-pricing): 每日自动刷新的编程 Agent 模型价目表，JSON / CSV 可直接引用，网页版把每百万 token 价格和跑分排名放在同一行。
-40. [llm-cost-calculator](https://github.com/xyzs996/llm-cost-calculator): 单文件网页算价器，读上面那份 JSON，按调用时刻判 DeepSeek 峰谷价、按实际长度判长上下文档位、按自己的缓存命中率折算。
+39. [llm-api-pricing](https://github.com/xyzs996/llm-api-pricing): 每日从 OpenRouter 重读的模型价目表，JSON / CSV 可直接引用；除每百万 token 价格外还给出缓存读价、长上下文档位和 DeepSeek 峰谷时段。
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
在「技巧 Tips」末尾补两条，都是我自己维护的，每天自动更新。

放这一节的理由是这里已经有第 8 条 `LLM Pricing`（一份 Google 表格）。那份表格好用，但要人手更新，也没法回答几个真正决定账单的问题。这两条补的正是那几个：

- **llm-api-pricing** — 价目表每天从 OpenRouter 实时清单重新生成，JSON / CSV 可以直接被别的程序引用；网页版把「每百万 token 多少钱」和「跑分排第几」放在同一行，回答的是「分数够用的里面哪个最便宜」。
- **llm-cost-calculator** — 单个 HTML 文件，不用装、不用注册，读的就是上面那份 JSON。价目表结构上答不了三件事，它按调用去算：DeepSeek 的峰谷价落在哪一边（2026-08-22 生效的周末规则是按北京时间划的，不是 UTC）、请求长度有没有越过长上下文档位（Gemini 3.1 Pro 的 20 万那条线，多一个 token 就从 $0.2060 跳到 $0.4090）、以及自己这边缓存命中占多少。

如果放在「代码 Coding」或者直接接在第 8 条后面更合适，我改。
