### PR TITLE
Add Clickyy — macOS screen-aware GUI agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@
 - Molt: https://github.com/NVIDIA-NeMo/labs-molt
 - prime-rl: https://github.com/PrimeIntellect-ai/prime-rl
 
+- [Clickyy](https://github.com/jayamitkatariya/clickyyy) - Open-source macOS menu bar AI agent: shake cursor to summon an overlay that sees your screen and can click, type, and act.
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>
 </div>


### PR DESCRIPTION
Add [Clickyy](https://github.com/jayamitkatariya/clickyyy) — open-source macOS menu bar AI agent (GUI/computer-use). Shake cursor to summon; it screenshots the screen, answers questions, and can click/type/scroll to finish tasks safely. MIT.