### PR TITLE
Add Lune Research to 研究 Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 - Kahneman4Review: https://huggingface.co/spaces/nuojohnchen/Kahneman4Review
 - Academic Figure Generator: https://github.com/LigphiDonk/academic-figure-generator
 - PaperFit: https://github.com/OpenRaiser/PaperFit
+- Lune Research: https://github.com/RetrogradeLabs/lune-mcp-server
 
 #### 全自动科研
 


### PR DESCRIPTION
在 `## 研究 Research` 的 `#### 其他` 追加一条：[Lune Research](https://github.com/RetrogradeLabs/lune-mcp-server)。格式与相邻条目一致，只增加一行。

**这是什么。** 一个 MCP 服务器，让 AI 编程助手（Claude Code、Codex、Cursor）直接基于顶会论文全文工作，而不是网页文本。语料限定在同行评审场所（NeurIPS、ICLR、ACL、CVPR、USENIX Security、IEEE S&P），支持双向引用追踪，核查论断时会返回论文原文中的支持性引句，因此生成的引用可以被核对而不是只能选择相信。共 12 个工具和 6 个 prompt，支持 Streamable HTTP 与 stdio。MIT 协议，已收录于官方 MCP Registry（`com.luneresearch/lune`）。

**关于放置位置。** 我放在了 `#### 其他`，因为 `写作`、`审稿`、`PPT`、`全自动科研` 都不贴切，而这个工具做的是文献检索与引用核查。如果以后这类工具变多，或许值得单开一个 `#### 检索` 子章节，这个由您决定，我没有擅自新增标题。

Filed in Chinese since the section headings and much of this list are; happy to switch to English if you prefer. Disclosure: I work on this tool.