### PR TITLE
Add Bifrost

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 53. [xLLM](https://github.com/jd-opensource/xllm): A high-performance inference engine for LLMs, optimized for diverse AI accelerators.
 54. [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX): OpenAI-compatible local LLM inference server for Apple Silicon, 2-4x faster than Ollama.
 55. [TokenSpeed](https://github.com/lightseekorg/tokenspeed): a speed-of-light LLM inference engine designed for agentic workloads, with TensorRT-LLM-level performance and vLLM-level usability. Our goal is to be the most performant inference engine for production agentic workloads.
+56. [Bifrost](https://github.com/maximhq/bifrost): LLM gateway with a unified API, multi-provider routing, load balancing, fallbacks, guardrails, and observability.
 
 
 <div align="right">


### PR DESCRIPTION
Adds Bifrost as item 56 under 推理 Inference. Bifrost is a self-hostable LLM gateway with a unified API, multi-provider routing, load balancing, fallbacks, guardrails, and observability. The existing numbering is preserved.