### PR TITLE
Add TeamoRouter to \u4f53\u9a8c Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 1. [LM Arena](https://lmarena.ai/zh)
 2. [Design Arena](https://www.designarena.ai/)
 3. [Vals AI](https://www.vals.ai/home) `evaluation`
+4. [TeamoRouter](https://teamorouter.cn?utm_source=github&utm_medium=awesome-list&utm_campaign=usage): An LLM gateway aggregating Claude, GPT, Gemini & DeepSeek under one OpenAI-compatible API — unified routing, per-key billing and auditable cost control.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Add TeamoRouter to the 体验 (Usage) list.

An LLM gateway aggregating Claude, GPT, Gemini & DeepSeek under one OpenAI-compatible API — 用统一端点体验/接入多模型，独立 key、按量计费、账单可审计。

Links:
- Gateway: https://teamorouter.cn?utm_source=github&utm_medium=awesome-list&utm_campaign=usage
- AI 编程模型性价比排名: https://teamorouter.cn/blogs/2026-ai-coding-models-price-performance-ranking
- API 文档: https://teamorouter.cn/docs/api-integration