### PR TITLE
Add OpenRoutiQ to Inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 54. [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX): OpenAI-compatible local LLM inference server for Apple Silicon, 2-4x faster than Ollama.
 55. [TokenSpeed](https://github.com/lightseekorg/tokenspeed): a speed-of-light LLM inference engine designed for agentic workloads, with TensorRT-LLM-level performance and vLLM-level usability. Our goal is to be the most performant inference engine for production agentic workloads.
 56. [FreeToken](https://github.com/FlashML-org/FreeToken): Unlock datacenter-class intelligence on the hardware you already own.
+57. [OpenRoutiQ](https://github.com/antat-ai/openroutiq): An explainable, policy-controlled Python router for selecting models, providers, deployments, and reasoning levels, with optional outcome learning and an OpenAI-compatible proxy.
 
 
 <div align="right">


### PR DESCRIPTION
## Summary

- Add OpenRoutiQ to the Inference section.
- Describe its explainable, policy-controlled routing across models, providers, deployments, and reasoning levels.

## Validation

- Confirmed there is no existing OpenRoutiQ entry or open submission.
- Confirmed the numbered-list placement.
- Ran git diff --check.

## Disclosure

I maintain OpenRoutiQ through the antat-ai organization.