### PR TITLE
Add FutureOS to Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 35. [EvoAgentX](https://github.com/EvoAgentX/EvoAgentX): Building a Self-Evolving Ecosystem of AI Agents.
 36. [ii-agent](https://github.com/Intelligent-Internet/ii-agent): a new open-source framework to build and deploy intelligent agents.
 37. [OWL](https://github.com/camel-ai/owl): Optimized Workforce Learning for General Multi-Agent Assistance in Real-World Task Automation.
+38. [FutureOS](https://github.com/futuregene/future-os): One AI agent, everywhere you work — a single Rust gRPC backend drives a terminal UI, desktop app, mobile apps, CLI, and IM bots with the same sessions, memory, and skills. Approval-gated tools, 3,800+ models, and a loop control plane for 24h+ runs.
 38. [OpenManus](https://github.com/FoundationAgents/OpenManus): No fortress, purely open ground. OpenManus is Coming.
 39. [JoyAgent-JDGenie](https://github.com/jd-opensource/joyagent-jdgenie): 业界首个开源高完成度轻量化通用多智能体产品.
 40. [coze-studio](https://github.com/coze-dev/coze-studio): An AI agent development platform with all-in-one visual tools, simplifying agent creation, debugging, and deployment like never before.


### PR DESCRIPTION
Adds [FutureOS](https://github.com/futuregene/future-os) to the **智能体 Agents** section (as #38).

FutureOS is an open-source AI agent that runs everywhere — terminal UI, desktop app, mobile apps, CLI, and Feishu/DingTalk IM bots — from a single Rust gRPC backend. Same sessions, memory, and skills on every surface; approval-gated tool execution; 3,800+ models across 140+ providers; a built-in loop control plane for long-horizon runs of 24+ hours.