### PR TITLE
Add AI Talks tutorial resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1057,6 +1057,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 36. [Implementation of all RAG techniques in a simpler way.](https://github.com/FareedKhan-dev/all-rag-techniques)
 37. [Theoretical Machine Learning: A Handbook for Everyone](https://www.tengjiaye.com/mlbook.html)
 38. [鱼皮的 Vibe Coding 零基础教程](https://github.com/liyupi/ai-guide)
+39. [AI Talks](https://aietalks.com/)
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Adds AI Talks to the tutorial list, following its concise resource-link format.

Disclosure: I maintain AI Talks, a free archive of AI Engineer talk summaries.
