### PR TITLE
新增 OrcaReplay 到 代码 Coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 25. [Multica](https://github.com/multica-ai/multica)
 26. [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent)
 27. [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+28. [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay)：录制 Claude Code / Codex / opencode 的运行，断网逐字节重放，或从任意检查点分叉换个模型重跑。
 
 
 <div align="right">


### PR DESCRIPTION
在 `## 代码 Coding` 末尾新增一条（第 28 项），其余未改动。

`28. [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay)：录制 Claude Code / Codex / opencode 的运行，断网逐字节重放，或从任意检查点分叉换个模型重跑。`

## 为什么放在这个分类

这一节里已经有的 Claude Code、Codex、opencode、Gemini CLI，正是它录制的对象；第 1 条 Cloi CLI 也是调试类工具，所以本节收调试工具有先例。

它解决的问题是：Agent 半夜删了你的迁移文件，早上想复现，重跑一次却是另一个结果。OrcaReplay 把那次运行存成一个文件，之后断网重放，逐字节一样；也可以从第 4 步分叉，换成另一个模型接着跑，让模型成为唯一变量。

捕获发生在 Agent 之下——模型 API 走本地代理，另有 PATH shim 记 Shell 退出码与耗时、JSON-RPC tee 记 MCP、影子 git index 记每轮文件改动。所以不用改 Agent，也不要求 Agent 是你写的：用 ChatGPT 订阅登录的 Codex CLI 没有 base URL 可改，照样能录。

- Apache-2.0，Node 20+，npm 包 `orcareplay`
- trace 格式是一份 CC BY 4.0 的规范，别人可以用其他语言重写 reader
- 网关地址是可以随便改的普通 URL，指向任何兼容网关都行
- README 与 capture 文档都有中文版

利益相关：我是 OrcaReplay 的开发者。项目 2026 年 8 月底开源，目前 69 star，属于早期项目，是否收录请维护者判断。
