### PR TITLE
Add FutureOS to 智能体 Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 51. [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open-source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, MCP, and more.
 52. [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh): The AI Agent Workforce Platform. Self-hostable multi-agent orchestration with remote AI workstations (AgentPods), PTY sandbox + git worktree isolation, channels-based agent collaboration, built-in Kanban, and per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode.
 53. [BitFun](https://github.com/GCWing/BitFun): Open-source agentic development environment with a Rust/Tauri desktop app and CLI for coding, research, office work, browser and desktop automation, extensible through MCP, Skills, and custom agents.
+54. [FutureOS](https://github.com/futuregene/future-os): One AI agent across terminal, desktop, mobile, CLI, and IM bots from a single Rust gRPC backend, with a loop control plane for 24h+ multi-agent runs.
 
 #### Harness
 


### PR DESCRIPTION
Adds [FutureOS](https://github.com/futuregene/future-os) to the **智能体 Agents** section (as #54).

FutureOS is an open-source AI agent that runs everywhere — terminal UI, desktop app, mobile apps, CLI, and Feishu/DingTalk IM bots — from a single Rust gRPC backend. Same sessions, memory, and skills on every surface; approval-gated tool execution; and a built-in loop control plane for long-horizon runs of 24+ hours.