### PR TITLE
Add HAT: training agents to adapt to evolving harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,8 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 4. [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness): Your Automated Agent Builder, Right on Your Desktop / Server.
 5. [FrontierAgent](https://github.com/ApodexAI/FrontierAgent): an open-source agent runtime, terminal product, and evaluation suite for long-horizon research and file-based work.
 
+6. [Training Agents to Evolve with Their Harness: TaoLive Digital Avatar Agent Technical Report](https://arxiv.org/abs/2608.15763): 技术报告；通过 Harness-State Augmentation 训练模型适应 Skills、工具、提示词和 Hooks 的变化，并报告淘宝直播数字人应用结果。
+
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>
 </div>


### PR DESCRIPTION
Thank you for maintaining such a broad LLM resource map. The separate Harness section makes it easier to connect agent runtimes with the rest of the training stack.

I'm Yuhan Sun, one of the authors of [Training Agents to Evolve with Their Harness: TaoLive Digital Avatar Agent Technical Report](https://arxiv.org/abs/2608.15763).

This adds a clearly labeled technical report on training compact agents to adapt to changing harnesses. It complements the runtime projects in the section with evidence from held-out runtime changes and a live-commerce application.

感谢长期维护这份资源库。我在 Harness 栏目补充了一篇训练与应用技术报告，标签和说明都保留为论文，不把研究资料仓库当作已开源的运行框架。

Thank you for considering the addition.
