### PR TITLE
Add YYLO to the Coding section

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 25. [Multica](https://github.com/multica-ai/multica)
 26. [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent)
 27. [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
+28. [YYLO](https://github.com/yylo-dev/yylo): Open-source command-line orchestrator for coding agents, with repeatable workflows, receipt-backed repository changes, and typed task, validation, merge, and release-readiness boundaries.
 
 
 <div align="right">


### PR DESCRIPTION
## Summary

Adds [YYLO](https://github.com/yylo-dev/yylo) — an open-source command-line orchestrator for coding agents — as entry 28 at the tail of the **代码 Coding** section, right beside the coding-agent band (Cloi CLI, Kimi-CLI, OpenCode, Claude Code, Codex, Gemini CLI, DeepSeek Harness).

- One entry, one file (`README.md`), +1/−0, tail append (no renumbering), matching the shape of recently merged additions (#189 Atomic Agent, #188 BitFun).
- Description phrases are taken verbatim from the project README: "command-line orchestrator for coding agents", "repeatable workflows", "receipt-backed repository changes", "typed task, validation, merge, and release-readiness boundaries".

## About YYLO

YYLO runs coding-agent loops from the terminal and wraps them in typed task, validation, merge, and release-readiness boundaries, so agent work lands as reviewable, receipt-backed repository changes:

- MIT-licensed, 57★, actively developed (daily commits, ~8 months old)
- npm: [`@yylo/cli`](https://www.npmjs.com/package/@yylo/cli) (~780 downloads/month)

## Validation

- [x] Entry follows the section's numbered-list format (`28. [Name](url): Description.`)
- [x] Appended at the section tail; no other lines touched
- [x] Single project, single PR

## Disclosure

I'm part of the YYLO team and prepared this PR with AI assistance, disclosed per this list's anti-link-farming norms (one venue, one project, one PR). Happy to reword the description or move the entry if the maintainer prefers a different phrasing or position.
