### PR TITLE
Add StudyArena to 体验 Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 2. [Design Arena](https://www.designarena.ai/)
 3. [Vals AI](https://www.vals.ai/home) `evaluation`
 4. [蚂蚁数科](https://maas.antdigital.com/models)
+5. [StudyArena](https://studyarena.com) - 免费比较同一学习问题的三个 AI 回答，投票后再揭晓模型。
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
我正在开发 StudyArena，想把它加入体验 Usage。它让学生先比较同一个问题的三个 AI 回答，再投票查看模型名称；三回答比较是免费的，模型选择和六回答比较属于 Supporter 功能。

这里已有 LM Arena 和 Design Arena，所以这个面向学习问题的盲评工具可以提供一个不同的使用场景。我在现有第四项后添加了第五项，只使用官网地址。

已检查仓库文件以及打开和关闭的 issue、PR，没有发现 StudyArena 或两个域名的重复记录。提交前检查了官网链接和单行 diff。
