### PR TITLE
Add Taskade to Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 51. [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open-source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, MCP, and more.
 52. [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh): The AI Agent Workforce Platform. Self-hostable multi-agent orchestration with remote AI workstations (AgentPods), PTY sandbox + git worktree isolation, channels-based agent collaboration, built-in Kanban, and per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode.
 53. [BitFun](https://github.com/GCWing/BitFun): Open-source agentic development environment with a Rust/Tauri desktop app and CLI for coding, research, office work, browser and desktop automation, extensible through MCP, Skills, and custom agents.
+54. [Taskade](https://www.taskade.com/create): AI-native workspace that builds apps, agents, and automations from a natural-language prompt.
 
 #### Harness
 


### PR DESCRIPTION
Adds Taskade to the Agents section, matching the numbered-list style of Coze, LinkAI, and Baidu APPBuilder.

- Taskade Genesis: https://www.taskade.com/create
- Apps: https://www.taskade.com/apps

I work at Taskade. One topic only: Taskade / Taskade Genesis.

Made with [Cursor](https://cursor.com)